### PR TITLE
Replace aliucord.tk with aliucord.com

### DIFF
--- a/TextReplace/src/main/kotlin/cloudburst/plugins/textreplace/utils/TextReplacement.kt
+++ b/TextReplace/src/main/kotlin/cloudburst/plugins/textreplace/utils/TextReplacement.kt
@@ -27,7 +27,7 @@ data class TextReplacement(
     companion object {
         val DEFAULT_LIST = arrayOf(
             TextReplacement("media.discordapp.net", "cdn.discordapp.com", false, true, true, false, false),
-            TextReplacement("bluesmods.com", "aliucord.tk", false, true, true, false, false),
+            TextReplacement("bluesmods.com", "aliucord.com", false, true, true, false, false),
         )
         public fun emptyRule(): TextReplacement {
             return TextReplacement("", "", false, true, true, true, true)


### PR DESCRIPTION
Replaces the old aliucord.tk domain to aliucord.com on a default text replace rule.
